### PR TITLE
Check preview CI NOT from fork

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,6 +3,9 @@
 
 # How to use Franklin
 
+Hello! This commit is **NOT** from the fork repository.
+Let's check docs preview!
+
 \tableofcontents <!-- you can use \toc as well -->
 
 This section is meant as a refresher if you're new to Franklin.


### PR DESCRIPTION
This PR modifies `index.md` **NOT** from a fork repository.
Let's see if preview docs will be generated correctly.
